### PR TITLE
Fix #41 - Back button has no effect in SearchActivity

### DIFF
--- a/explorer/src/androidTest/java/com/dnielfe/manager/SearchActivityIntegrationTest.java
+++ b/explorer/src/androidTest/java/com/dnielfe/manager/SearchActivityIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.dnielfe.manager;
+
+import android.app.Instrumentation;
+import android.test.ActivityInstrumentationTestCase2;
+import android.view.KeyEvent;
+import android.view.View;
+
+public class SearchActivityIntegrationTest
+        extends ActivityInstrumentationTestCase2<BrowserActivity> {
+    private Instrumentation mInstrumentation;
+    private BrowserActivity mBrowserActivity;
+    private SearchActivity mSearchActivity;
+
+    public SearchActivityIntegrationTest() {
+        super(BrowserActivity.class);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        setActivityInitialTouchMode(false);
+        mInstrumentation = getInstrumentation();
+        mBrowserActivity = getActivity();
+        mSearchActivity = getSearchActivityByMenuClick();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        mSearchActivity.finish();
+        mBrowserActivity.finish();
+    }
+
+    public void testPreconditions() {
+        assertTrue(mSearchActivity.hasWindowFocus());
+        assertFalse(mBrowserActivity.hasWindowFocus());
+    }
+
+    public void testNavBack_ByBackButton_DisplaysBrowserActivity() throws Exception {
+        this.sendKeys(KeyEvent.KEYCODE_BACK);
+        mInstrumentation.waitForIdleSync();
+        assertFalse(mSearchActivity.hasWindowFocus());
+        assertTrue(mBrowserActivity.hasWindowFocus());
+    }
+
+    private SearchActivity getSearchActivityByMenuClick() {
+        Instrumentation.ActivityMonitor activityMonitor =
+                mInstrumentation.addMonitor(SearchActivity.class.getName(), null, false);
+        mBrowserActivity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                View searchMenuItem = mBrowserActivity.findViewById(R.id.search);
+                assertNotNull(searchMenuItem);
+                searchMenuItem.performClick();
+            }
+        });
+        SearchActivity searchActivity =
+                (SearchActivity) activityMonitor.waitForActivityWithTimeout(2000);
+        mInstrumentation.removeMonitor(activityMonitor);
+        mInstrumentation.waitForIdleSync();
+        return searchActivity;
+    }
+}

--- a/explorer/src/androidTest/java/com/dnielfe/manager/SearchActivityIntegrationTest.java
+++ b/explorer/src/androidTest/java/com/dnielfe/manager/SearchActivityIntegrationTest.java
@@ -35,7 +35,7 @@ public class SearchActivityIntegrationTest
         assertFalse(mBrowserActivity.hasWindowFocus());
     }
 
-    public void testNavBack_ByBackButton_DisplaysBrowserActivity() throws Exception {
+    public void testNavBack_ByBackButton_DisplaysBrowserActivity() {
         this.sendKeys(KeyEvent.KEYCODE_BACK);
         mInstrumentation.waitForIdleSync();
         assertFalse(mSearchActivity.hasWindowFocus());

--- a/explorer/src/main/java/com/dnielfe/manager/SearchActivity.java
+++ b/explorer/src/main/java/com/dnielfe/manager/SearchActivity.java
@@ -135,14 +135,15 @@ public class SearchActivity extends ThemableActivity implements SearchView.OnQue
 
     @Override
     public boolean onKeyDown(int keycode, @NonNull KeyEvent event) {
-        if (keycode != KeyEvent.KEYCODE_BACK)
+        if (keycode != KeyEvent.KEYCODE_BACK) {
             return false;
+        }
 
         if (mActionController.isActionMode()) {
             mActionController.finishActionMode();
         }
 
-        return true;
+        return super.onKeyDown(keycode, event);
     }
 
     private class SearchTask extends AsyncTask<String, Void, ArrayList<String>> {


### PR DESCRIPTION
Changed onKeyDown() return from 'true' to a call to super. Fixes #41.
Test included.

Also added braces to a two-line conditional in the same method for
consistency with other conditionals, as well as to reduce risk of
introducing new bugs later.