### PR TITLE
Fix #32 - Copy, cut and paste are off screen... when renaming a file

### DIFF
--- a/explorer/src/main/res/values/styles.xml
+++ b/explorer/src/main/res/values/styles.xml
@@ -29,6 +29,12 @@
         <item name="action_bookmark">@drawable/holo_light_ic_bookmark</item>
         <item name="action_delete">@drawable/holo_light_action_delete</item>
         <item name="action_share">@drawable/holo_light_action_share</item>
+
+        <!-- pre-lollipop Theme.AppCompat action mode drawables (for AlertDialog, issue #32) -->
+        <!-- TODO: remove when android.support.v7.AlertDialog is implemented -->
+        <item name="actionModeSelectAllDrawable">@drawable/holo_light_action_select_all</item>
+        <item name="actionModeCutDrawable">@drawable/holo_light_action_cut</item>
+        <item name="actionModeCopyDrawable">@drawable/holo_light_action_copy</item>
     </style>
 
     <style name="ThemeDark" parent="Theme.AppCompat.NoActionBar">
@@ -59,6 +65,12 @@
         <item name="action_bookmark">@drawable/holo_dark_ic_bookmark</item>
         <item name="action_delete">@drawable/holo_dark_action_delete</item>
         <item name="action_share">@drawable/holo_dark_action_share</item>
+
+        <!-- pre-lollipop Theme.AppCompat action mode drawables (for AlertDialog, issue #32) -->
+        <!-- TODO: remove when android.support.v7.AlertDialog is implemented -->
+        <item name="actionModeSelectAllDrawable">@drawable/holo_dark_ic_action_select_all</item>
+        <item name="actionModeCutDrawable">@drawable/holo_dark_action_cut</item>
+        <item name="actionModeCopyDrawable">@drawable/holo_dark_action_copy</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Bug in Theme.AppCompat (appcompat-v7:22.1.0 and appcompat-v7:22.1.1)
implements white, untinted AppCompat ActionMode icons in both Light
and Dark themes on pre-Lollipop devices, resulting in white-on-white
invisible icons in the Light theme.

Note that Lollipop devices seem to fall back to the platform theme
with correctly tinted icons, so they are unaffected by the bug.

This affects any Text Selection ActionMode, wherever a TextView or an
EditText has textIsSelectable enabled.  This includes RenameDialog,
CreateFileDialog, and CreateFolderDialog.

Implementing android.support.v7.AlertDialog for these dialogs is the
best long-term fix for the issue, but it has blocking bugs in the
current appcompat version.

Assigned existing light and dark holo icons for Select All, Cut, and
Copy to the corresponding Theme.AppCompat attributes in the two child
themes in styles.xml.  These can be removed when
android.support.v7.AlertDialog is fixed and implemented.

This provides visible icons in the Text Selection ActionMode on
pre-Lollipop devices, without affecting those on Lollipop.