### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/explorer/src/main/java/com/dnielfe/manager/preview/MimeTypes.java
+++ b/explorer/src/main/java/com/dnielfe/manager/preview/MimeTypes.java
@@ -12,6 +12,8 @@ import java.util.regex.Pattern;
 
 public final class MimeTypes {
 
+    private MimeTypes() {}
+
     private static final HashMap<String, Integer> EXT_ICONS = new HashMap<>();
     private static final HashMap<String, String> MIME_TYPES = new HashMap<>();
 

--- a/explorer/src/main/java/com/dnielfe/manager/settings/Settings.java
+++ b/explorer/src/main/java/com/dnielfe/manager/settings/Settings.java
@@ -10,6 +10,8 @@ import com.stericson.RootTools.RootTools;
 
 public final class Settings {
 
+    private Settings() {}
+
     private static SharedPreferences mPrefs;
 
     public static int mTheme;

--- a/explorer/src/main/java/com/dnielfe/manager/utils/MediaStoreUtils.java
+++ b/explorer/src/main/java/com/dnielfe/manager/utils/MediaStoreUtils.java
@@ -14,6 +14,8 @@ import java.io.File;
 
 public abstract class MediaStoreUtils {
 
+    private MediaStoreUtils() {}
+
     public static Uri getUriFromFile(final String path, Context context) {
         ContentResolver resolver = context.getContentResolver();
 

--- a/explorer/src/main/java/com/dnielfe/manager/utils/RootCommands.java
+++ b/explorer/src/main/java/com/dnielfe/manager/utils/RootCommands.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 
 public class RootCommands {
 
+    private RootCommands() {}
+
     private static final String UNIX_ESCAPE_EXPRESSION = "(\\(|\\)|\\[|\\]|\\s|\'|\"|`|\\{|\\}|&|\\\\|\\?)";
 
     private static String getCommandLineString(String input) {

--- a/explorer/src/main/java/com/dnielfe/manager/utils/SimpleUtils.java
+++ b/explorer/src/main/java/com/dnielfe/manager/utils/SimpleUtils.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 
 public class SimpleUtils {
 
+    private SimpleUtils() {}
+
     private static final int BUFFER = 16384;
     private static final long ONE_KB = 1024;
     private static final BigInteger KB_BI = BigInteger.valueOf(ONE_KB);

--- a/explorer/src/main/java/com/dnielfe/manager/utils/SortUtils.java
+++ b/explorer/src/main/java/com/dnielfe/manager/utils/SortUtils.java
@@ -10,6 +10,8 @@ import java.util.Comparator;
 
 public class SortUtils {
 
+    private SortUtils() {}
+
     private static final int SORT_ALPHA = 0;
     private static final int SORT_TYPE = 1;
     private static final int SORT_SIZE = 2;

--- a/explorer/src/main/java/com/dnielfe/manager/utils/ZipUtils.java
+++ b/explorer/src/main/java/com/dnielfe/manager/utils/ZipUtils.java
@@ -13,6 +13,8 @@ import java.util.zip.ZipOutputStream;
 
 public class ZipUtils {
 
+    private ZipUtils() {}
+
     private static final int BUFFER = 8192;
 
     public static void createZip(String[] files, String zipFile) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed